### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You are able to switch between displyaing modes by setting the **mode** property
 @property (nonatomic) TLTagsControlMode mode;
 ```
 
-######TLTagsControl has two displaying modes:
+###### TLTagsControl has two displaying modes:
 ```
 TLTagsControlModeEdit,
 ```
@@ -46,7 +46,7 @@ To apply your changes you should call the method below
 - (void)reloadTagSubviews;
 ```
 
-######Example:
+###### Example:
 
 ```
 //assuming tagControl will be set initialized from stroryboard


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
