### PR TITLE
fixed a bug where commonInit was called twice

### DIFF
--- a/TLTagsContol/TLTagsControl.m
+++ b/TLTagsContol/TLTagsControl.m
@@ -63,7 +63,6 @@
 
 - (void)awakeFromNib {
     [super awakeFromNib];
-    [self commonInit];
 }
 
 - (void)commonInit {

--- a/TLTagsContol/TLTagsControl.m
+++ b/TLTagsContol/TLTagsControl.m
@@ -61,10 +61,6 @@
     return self;
 }
 
-- (void)awakeFromNib {
-    [super awakeFromNib];
-}
-
 - (void)commonInit {
     _tags = [NSMutableArray array];
     


### PR DESCRIPTION
when used in a storyboard or a xib, initWithCoder and also awakeFromNib will call commonInit and 2 textFields will be visible in the hierarchy.